### PR TITLE
feat: add company name on four endpoints

### DIFF
--- a/api-references/helper-list/companies-index.mdx
+++ b/api-references/helper-list/companies-index.mdx
@@ -52,10 +52,10 @@ description: "Return list of companies from a stock index"
   Array of companies of the given index.
   <Expandable title="properties">
     <ResponseField name="Company.symbol" type="string" required>
-      The company ticker.
+      The ticker of the company.
     </ResponseField>
     <ResponseField name="Company.company_name" type="string" required>
-      The company legal name.
+      The full name of the company.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/api-references/helper-list/companies-index.mdx
+++ b/api-references/helper-list/companies-index.mdx
@@ -6,7 +6,16 @@ description: "Return list of companies from a stock index"
 
 <ResponseExample>
 ```json 200
-["ACES.JK", "ADRO.JK", "AKRA.JK", "UNVR.JK"]
+[
+  {
+    "symbol": "NISP.JK",
+    "company_name": "PT Bank OCBC NISP Tbk"
+  },
+  {
+    "symbol": "PNBN.JK",
+    "company_name": "Bank Pan Indonesia Tbk"
+  }
+]
 ```
 
 ```json 429
@@ -39,8 +48,16 @@ description: "Return list of companies from a stock index"
 
 ### Response
 
-<ResponseField name="payload" type="string[]" required>
-  Array of tickers of the given index.
+<ResponseField name="payload" type="Company[]" required>
+  Array of companies of the given index.
+  <Expandable title="properties">
+    <ResponseField name="Company.symbol" type="string" required>
+      The company ticker.
+    </ResponseField>
+    <ResponseField name="Company.company_name" type="string" required>
+      The company legal name.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 
 ### Usage

--- a/api-references/helper-list/companies-subindustry.mdx
+++ b/api-references/helper-list/companies-subindustry.mdx
@@ -60,10 +60,10 @@ description: "Return list of companies from a subindustry"
   Array of companies of the given subindustry.
   <Expandable title="properties">
     <ResponseField name="Company.symbol" type="string" required>
-      The company ticker.
+      The ticker of the company.
     </ResponseField>
     <ResponseField name="Company.company_name" type="string" required>
-      The company legal name.
+      The full name of the company.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/api-references/helper-list/companies-subindustry.mdx
+++ b/api-references/helper-list/companies-subindustry.mdx
@@ -7,9 +7,14 @@ description: "Return list of companies from a subindustry"
 <ResponseExample>
 ```json 200
 [
-  "BALI.JK",
-  "BTEL.JK",
-  "CENT.JK",
+  {
+    "symbol": "NISP.JK",
+    "company_name": "PT Bank OCBC NISP Tbk"
+  },
+  {
+    "symbol": "PNBN.JK",
+    "company_name": "Bank Pan Indonesia Tbk"
+  }
 ]
 ```
 
@@ -51,8 +56,16 @@ description: "Return list of companies from a subindustry"
 
 ### Response
 
-<ResponseField name="payload" type="string[]" required>
-  Array of tickers of the given subindustry.
+<ResponseField name="payload" type="Company[]" required>
+  Array of companies of the given subindustry.
+  <Expandable title="properties">
+    <ResponseField name="Company.symbol" type="string" required>
+      The company ticker.
+    </ResponseField>
+    <ResponseField name="Company.company_name" type="string" required>
+      The company legal name.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 
 ### Usage

--- a/api-references/helper-list/companies-subsector.mdx
+++ b/api-references/helper-list/companies-subsector.mdx
@@ -59,10 +59,10 @@ description: "Return list of companies from a subsector"
   Array of companies of the given subsector.
   <Expandable title="properties">
     <ResponseField name="Company.symbol" type="string" required>
-      The company ticker.
+      The ticker of the company.
     </ResponseField>
     <ResponseField name="Company.company_name" type="string" required>
-      The company legal name.
+      The full name of the company.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/api-references/helper-list/companies-subsector.mdx
+++ b/api-references/helper-list/companies-subsector.mdx
@@ -7,9 +7,14 @@ description: "Return list of companies from a subsector"
 <ResponseExample>
 ```json 200
 [
-  "BALI.JK",
-  "BTEL.JK",
-  "CENT.JK",
+  {
+    "symbol": "NISP.JK",
+    "company_name": "PT Bank OCBC NISP Tbk"
+  },
+  {
+    "symbol": "PNBN.JK",
+    "company_name": "Bank Pan Indonesia Tbk"
+  }
 ]
 ```
 
@@ -39,7 +44,7 @@ description: "Return list of companies from a subsector"
       endpoint.
     </Accordion>
     <Accordion title="Examples of the sub_sector">
-      `bank`, `financing-service`, `insurance`, `retailing`, `tobacco`
+      `banks`, `financing-service`, `insurance`, `retailing`, `tobacco`
     </Accordion>
     <Accordion title="Format">
       The API endpoint only accepts `sub_sector` in the **kebab case** format
@@ -50,8 +55,16 @@ description: "Return list of companies from a subsector"
 
 ### Response
 
-<ResponseField name="payload" type="string[]" required>
-  Array of tickers of the given subsector.
+<ResponseField name="payload" type="Company[]" required>
+  Array of companies of the given subsector.
+  <Expandable title="properties">
+    <ResponseField name="Company.symbol" type="string" required>
+      The company ticker.
+    </ResponseField>
+    <ResponseField name="Company.company_name" type="string" required>
+      The company legal name.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 
 ### Usage

--- a/api-references/transaction/most-traded.mdx
+++ b/api-references/transaction/most-traded.mdx
@@ -88,7 +88,7 @@ description: "Return a list of the most traded tickers based on transaction volu
     <ResponseField name="TradedData.symbol" type="string" required>
       The ticker of the traded stock.
     </ResponseField>
-    <ResponseField name="TradedData.symbol" type="string" required>
+    <ResponseField name="TradedData.company_name" type="string" required>
       The company name of the traded stock.
     </ResponseField>
     <ResponseField name="TradedData.volume" type="integer" required>

--- a/api-references/transaction/most-traded.mdx
+++ b/api-references/transaction/most-traded.mdx
@@ -8,11 +8,12 @@ description: "Return a list of the most traded tickers based on transaction volu
 ```json 200
 {
     "2024-05-21": [
-        {
-            "symbol": "SOLA.JK",
-            "volume": 0,
-            "price": 0
-        }
+      {
+        "symbol": "GOTO.JK",
+        "company_name": "PT GoTo Gojek Tokopedia Tbk",
+        "volume": 0,
+        "price": 0
+      }
     ]
 }
 ```
@@ -86,6 +87,9 @@ description: "Return a list of the most traded tickers based on transaction volu
   <Expandable title="properties">
     <ResponseField name="TradedData.symbol" type="string" required>
       The ticker of the traded stock.
+    </ResponseField>
+    <ResponseField name="TradedData.symbol" type="string" required>
+      The company name of the traded stock.
     </ResponseField>
     <ResponseField name="TradedData.volume" type="integer" required>
       The transaction volume on the specified date.

--- a/api-references/transaction/top-tickers.mdx
+++ b/api-references/transaction/top-tickers.mdx
@@ -8,28 +8,32 @@ description: "Return a list of top tickers in a given year based on certain clas
 ```json 200
 {
     "dividend_yield": [
-        {
-            "symbol": "SCPI.JK",
-            "dividend_yield": 0
-        }
+      {
+        "symbol": "BJTM.JK",
+        "company_name": "Bank Pembangunan Daerah Jawa Timur Tbk",
+        "dividend_yield": 0
+      }
     ],
     "total_dividend": [
-        {
-            "symbol": "SCPI.JK",
-            "total_dividend": 0
-        }
+      {
+        "symbol": "BJTM.JK",
+        "company_name": "Bank Pembangunan Daerah Jawa Timur Tbk",
+        "total_dividend": 0
+      }
     ],
     "revenue": [
-        {
-            "symbol": "ASII.JK",
-            "revenue": 0
-        }
+      {
+        "symbol": "BJTM.JK",
+        "company_name": "Bank Pembangunan Daerah Jawa Timur Tbk",
+        "revenue": 0
+      }
     ],
     "earnings": [
-        {
-            "symbol": "BBRI.JK",
-            "earnings": 0
-        }
+      {
+        "symbol": "BJTM.JK",
+        "company_name": "Bank Pembangunan Daerah Jawa Timur Tbk",
+        "earnings": 0
+      }
     ]
 }
 ```
@@ -85,6 +89,9 @@ description: "Return a list of top tickers in a given year based on certain clas
     <ResponseField name="DividendYieldData.symbol" type="string" required>
       The ticker of the company.
     </ResponseField>
+    <ResponseField name="DividendYieldData.company_name" type="string" required>
+      The name of the company.
+    </ResponseField>
     <ResponseField
       name="DividendYieldData.dividend_yield"
       type="float"
@@ -99,6 +106,9 @@ description: "Return a list of top tickers in a given year based on certain clas
   <Expandable title="properties">
     <ResponseField name="TotalDividendData.symbol" type="string" required>
       The ticker of the company.
+    </ResponseField>
+    <ResponseField name="TotalDividendData.company_name" type="string" required>
+      The name of the company.
     </ResponseField>
     <ResponseField
       name="TotalDividendData.total_dividend"
@@ -115,6 +125,9 @@ description: "Return a list of top tickers in a given year based on certain clas
     <ResponseField name="RevenueData.symbol" type="string" required>
       The ticker of the company.
     </ResponseField>
+    <ResponseField name="RevenueData.company_name" type="string" required>
+      The name of the company.
+    </ResponseField>
     <ResponseField name="RevenueData.revenue" type="float" required>
       The total revenue of the company in IDR.
     </ResponseField>
@@ -125,6 +138,9 @@ description: "Return a list of top tickers in a given year based on certain clas
   <Expandable title="properties">
     <ResponseField name="EarningsData.symbol" type="string" required>
       The ticker of the company.
+    </ResponseField>
+    <ResponseField name="EarningsData.company_name" type="string" required>
+      The name of the company.
     </ResponseField>
     <ResponseField name="EarningsData.earnings" type="float" required>
       The total earnings of the company in IDR.

--- a/recipes/animated-plots-in-r/01-top-stock-volume-animation-plot.mdx
+++ b/recipes/animated-plots-in-r/01-top-stock-volume-animation-plot.mdx
@@ -29,7 +29,7 @@ After installing the necessary packages and loading the libraries, we can start 
 library(httr)
 
 # Replace the URL with a URL from the Available Endpoints section
-url <- "https://api.sectors.app/v1/most-traded/?start=2024-01-01&end=2024-03-24&n_stocks=10" #Top 10 Daily most traded stocks from 1st January 2024 to 24th March 2024
+url <- "https://api.sectors.app/v1/most-traded/?start=2024-01-01&end=2024-03-24&n_stock=10" #Top 10 Daily most traded stocks from 1st January 2024 to 24th March 2024
 api_key <- "YOUR API KEY"
 
 headers <- c(Authorization = api_key)
@@ -51,7 +51,7 @@ df <- do.call(rbind, lapply(names(data), function(date) {
   data.frame(
     date = rep(date, each = length(data[[date]])),
     symbol = unlist(lapply(data[[date]], function(x) x[[1]])),
-    volume = unlist(lapply(data[[date]], function(x) x[[2]]))
+    volume = unlist(lapply(data[[date]], function(x) x[[3]]))
   )
 }))
 ```

--- a/recipes/quick-start-in-python/01-list-all-subsectors.mdx
+++ b/recipes/quick-start-in-python/01-list-all-subsectors.mdx
@@ -115,7 +115,7 @@ for data in data_all_subsectors:
     if response.status_code == 200:
         list_companies_by_subsectors = response.json()
         for company in list_companies_by_subsectors:
-            result_data.append([subsector, company])
+            result_data.append([subsector, company["symbol"]])
     else:
         # Handle error
         print("Error Status :",response.status_code)

--- a/recipes/quick-start-in-python/02-company-revenue-by-subsector-analysis.mdx
+++ b/recipes/quick-start-in-python/02-company-revenue-by-subsector-analysis.mdx
@@ -41,12 +41,16 @@ headers = {
 }
 response = requests.get("https://api.sectors.app/v1/companies/?sub_sector=tobacco", headers = headers)
 
+list_companies_by_subsectors = []
 if response.status_code == 200:
-    list_companies_by_subsectors = response.json()
-    print(list_companies_by_subsectors)
+    data = response.json()
+    for company in data:
+        list_companies_by_subsectors.append(company["symbol"])
 else:
     # Handle error
     print("Error Status :",response.status_code)
+
+print(list_companies_by_subsectors)
 ```
 
 You should see an output like this:


### PR DESCRIPTION
Updated response example and response props for the following endpoint

- v1/companies/
- v1/companies/top/
- v1/most-traded/
- v1/index/{index}/