### PR TITLE
docs: add Sectors MCP OAuth guides for Claude and ChatGPT

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -340,7 +340,9 @@
       "group": "Sectors for AI Agents",
       "pages": [
         "recipes/sectors-for-ai-agents/00-sectors-mcp-guide",
-        "recipes/sectors-for-ai-agents/01-agent-skills-guide"
+        "recipes/sectors-for-ai-agents/01-agent-skills-guide",
+        "recipes/sectors-for-ai-agents/02-sectors-in-claude",
+        "recipes/sectors-for-ai-agents/03-sectors-in-chatgpt"
       ]
     },
     {

--- a/recipes/sectors-for-ai-agents/00-sectors-mcp-guide.mdx
+++ b/recipes/sectors-for-ai-agents/00-sectors-mcp-guide.mdx
@@ -48,34 +48,9 @@ Before beginning, make sure you have:
 
 ## Quick Start Setup
 
-### Claude Desktop
-Open your Claude Desktop config file:
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-Add the following to your `mcpServers` object:
-
-```json
-{
-  "mcpServers": {
-    "sectors": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://sectors-mcp.supertype.ai/sse",
-        "--header",
-        "Authorization:${AUTH_TOKEN}"
-      ],
-      "env": {
-        "AUTH_TOKEN": "Bearer YOUR_API_KEY_HERE"
-      }
-    }
-  }
-}
-```
-
-Replace `YOUR_API_KEY_HERE` with your Sectors Financial API key, then restart Claude Desktop. The Sectors tools will appear in the tools panel.
+<Note>
+  **Using Claude (web or desktop)?** Skip this section — Claude supports a one-click OAuth custom connector that doesn't require an API key in a config file. See [Connect Sectors to Claude with OAuth](/recipes/sectors-for-ai-agents/02-sectors-in-claude).
+</Note>
 
 ### Claude Code
 Run the following command in your terminal:
@@ -348,27 +323,6 @@ Restart your client completely after adding the config — most clients only loa
 
 **VS Code keeps prompting me for the API key on every session.**
 This is expected behavior. The VS Code config uses `${input:sectors-api-key}` which prompts you once per session and stores it securely in memory. It won't persist across restarts by design.
-
-**I'm on Windows and the server fails to connect in Claude Desktop.**
-Claude Desktop on Windows runs MCP servers via stdio, which requires wrapping `npx` calls with `cmd /c`. Update your config to:
-
-```json
-{
-  "mcpServers": {
-    "sectors": {
-      "command": "cmd",
-      "args": [
-        "/c", "npx", "-y", "mcp-remote",
-        "https://sectors-mcp.supertype.ai/sse",
-        "--header", "Authorization:${AUTH_TOKEN}"
-      ],
-      "env": {
-        "AUTH_TOKEN": "Bearer YOUR_API_KEY_HERE"
-      }
-    }
-  }
-}
-```
 
 ---
 

--- a/recipes/sectors-for-ai-agents/02-sectors-in-claude.mdx
+++ b/recipes/sectors-for-ai-agents/02-sectors-in-claude.mdx
@@ -1,0 +1,126 @@
+---
+title: "Connect Sectors to Claude with OAuth"
+sidebarTitle: "3. Sectors in Claude"
+---
+
+## Overview
+
+Sectors is available as a **custom connector** inside Claude — connect once with OAuth and Claude can pull live IDX, SGX, and KLSE data into any conversation. No API key to paste into a config file, no JSON to edit, and access is revocable from your Sectors dashboard at any time.
+
+This guide covers the OAuth flow on **claude.ai (web)** and the **Claude Desktop** app. If you're setting up Claude Code, Cursor, VS Code, or any other SSE-based client, see [Use Sectors MCP Server for Financial Analysis](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide).
+
+| Setup style | Best for | Auth | Endpoint |
+|---|---|---|---|
+| **OAuth custom connector** (this guide) | claude.ai, Claude Desktop | Browser sign-in | `https://sectors-mcp.supertype.ai/mcp` |
+| API key + SSE | Claude Code, Cursor, VS Code, JetBrains | `Bearer YOUR_API_KEY` header | `https://sectors-mcp.supertype.ai/sse` |
+
+## Prerequisites
+
+1. **A Sectors account on an Insider plan.**
+<Card title="Sign up for Insider" horizontal icon="key" href="https://sectors.app">
+  Required to authorize the connector and make API requests.
+</Card>
+
+2. **Claude on web or desktop** — sign in at [claude.ai](https://claude.ai) or install the [Claude Desktop app](https://claude.ai/download). The Connectors UI shown below is available on both surfaces.
+
+## Setup on claude.ai (Web)
+
+<Steps>
+  <Step title="Open Customize">
+    In the Claude sidebar, click **Customize**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-1.png" alt="Claude sidebar with Customize highlighted" />
+    </Frame>
+  </Step>
+
+  <Step title="Open Connectors">
+    In the Customize panel, click **Connectors**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-2.png" alt="Customize panel with Connectors highlighted" />
+    </Frame>
+  </Step>
+
+  <Step title="Add a custom connector">
+    Click the **+** button at the top of the Connectors list and choose **Add custom connector**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-3.png" alt="Add custom connector menu" />
+    </Frame>
+  </Step>
+
+  <Step title="Enter the Sectors connector details">
+    In the dialog, set:
+
+    - **Name**: `Sectors`
+    - **URL**: `https://sectors-mcp.supertype.ai/mcp`
+
+    Leave the advanced settings at their defaults and click **Add**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-4.png" alt="Add custom connector dialog with Sectors name and MCP URL" />
+    </Frame>
+  </Step>
+
+  <Step title="Authorize access">
+    Claude opens the Sectors authorization page in a new window. Review the requested permission (**Read access to Sectors API**) and click **Allow Access**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-5.png" alt="Sectors OAuth authorize access screen" />
+    </Frame>
+
+    Sign in to your Sectors account if you aren't already. Your existing subscription limits and credits apply to all requests made through the connector.
+  </Step>
+
+  <Step title="Confirm the connection">
+    Back in Connectors, **Sectors Mcp** now appears under **Web** with all 40 tools listed. From here you can toggle tool permissions individually (Always allow / Ask / Never) using the icons on the right of each tool row.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/claude-6.png" alt="Sectors MCP connected with 40 tools listed" />
+    </Frame>
+  </Step>
+</Steps>
+
+## Setup on Claude Desktop
+
+Claude Desktop uses the same Connectors UI as the web app. Open the Desktop app, click your profile → **Customize** → **Connectors**, then follow steps 3–6 above. The connector you add is synced to your Claude account, so a connector added on the web will also appear in Desktop and vice versa.
+
+<Note>
+  Make sure you're on a recent version of Claude Desktop. If **Connectors** doesn't appear under **Customize**, update the app from [claude.ai/download](https://claude.ai/download) and restart it.
+</Note>
+
+## Verify It Works
+
+Open a new chat and try:
+
+> Give me an overview of Bank Central Asia (BBCA) using the Sectors connector.
+
+Claude will request permission to call `fetch-company-report` (unless you've already set it to **Always allow**), then return the company's sector, market cap, last close price, and index memberships.
+
+If the tool call succeeds, you're done. For more example prompts and the full tools reference, see the [main Sectors MCP guide](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#usage-examples).
+
+## Managing Access
+
+- **Tool permissions** — In **Customize → Connectors → Sectors Mcp**, expand the tools list and set each tool to **Always allow**, **Ask**, or **Never**. This is per-tool and per-user.
+- **Disconnect** — Click **Disconnect** at the top of the connector panel to remove it from Claude.
+- **Revoke from Sectors** — You can also revoke the OAuth grant from your Sectors dashboard. After revoking, Claude tool calls will start failing with a 401 until you reconnect.
+
+## Troubleshooting
+
+**The connector doesn't show up after I add it.**
+Refresh the Connectors page, or close and reopen Claude. If you added it on Desktop and don't see it on the web (or vice versa), give it a few seconds — sync isn't always instant.
+
+**Authorization loops back to the login screen.**
+This usually means you're signed into the wrong Sectors account, or your session has expired. Open [sectors.app](https://sectors.app) in the same browser, confirm you're signed in, then retry the connector authorization.
+
+**Tools return `401 Unauthorized` after authorizing.**
+The OAuth grant may have been revoked from your Sectors dashboard, or your Insider subscription has lapsed. Reconnect the connector — Claude will redirect you to authorize again.
+
+**A tool returns an empty array.**
+Same causes as the SSE flow: wrong subsector slug, ticker not found, or a date range with no trading days. See the [data & coverage FAQ](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#data-coverage) in the main guide.
+
+## Next Steps
+
+- [Full tools reference and usage examples](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#tools-reference) — all 40 tools, what they return, key parameters.
+- [Sectors Agent Skills](/recipes/sectors-for-ai-agents/01-agent-skills-guide) — alternative integration that ships as a Claude Skill instead of an MCP connector.

--- a/recipes/sectors-for-ai-agents/03-sectors-in-chatgpt.mdx
+++ b/recipes/sectors-for-ai-agents/03-sectors-in-chatgpt.mdx
@@ -1,0 +1,145 @@
+---
+title: "Connect Sectors to ChatGPT with OAuth"
+sidebarTitle: "4. Sectors in ChatGPT"
+---
+
+## Overview
+
+Sectors can be connected to ChatGPT as a **custom MCP app**. Once added, ChatGPT can call any of the 40+ Sectors tools — company reports, top movers, quarterly financials, SGX coverage, and more — directly inside a chat. Authentication uses OAuth with Dynamic Client Registration, so there's no API key to copy and paste.
+
+This guide covers ChatGPT on the web. If you're using Claude or an SSE-based client, see:
+
+- [Connect Sectors to Claude with OAuth](/recipes/sectors-for-ai-agents/02-sectors-in-claude)
+- [Use Sectors MCP Server for Financial Analysis](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide) (Claude Code, Cursor, VS Code, etc.)
+
+## Prerequisites
+
+1. **A Sectors account on an Insider plan** — required to authorize the connector.
+<Card title="Sign up for Insider" horizontal icon="key" href="https://sectors.app">
+  You'll be redirected here during the OAuth step.
+</Card>
+
+2. **A ChatGPT plan that supports custom MCP apps in developer mode.** The exact tier list changes over time — see OpenAI's [Apps SDK / connectors documentation](https://platform.openai.com/docs/guides/apps-sdk) for the current requirements.
+
+<Note>
+  Custom MCP apps in ChatGPT live behind a **Developer mode** toggle that OpenAI labels **Elevated Risk**. While developer mode is on, ChatGPT disables **Memory** and warns that unverified connectors could modify or erase data. Only enable it when you need to use Sectors (or other custom apps), and disconnect apps you no longer use.
+</Note>
+
+## Setup
+
+<Steps>
+  <Step title="Open the Apps page">
+    In the ChatGPT sidebar, click **Apps**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-1.png" alt="ChatGPT sidebar with Apps highlighted" />
+    </Frame>
+  </Step>
+
+  <Step title="Open Apps settings">
+    On the Apps page, click the **gear icon** in the top right corner.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-2.png" alt="Apps page with settings gear highlighted" />
+    </Frame>
+  </Step>
+
+  <Step title="Open Advanced settings">
+    In the settings dialog, make sure **Apps** is selected in the left sidebar, then click **Advanced settings**.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-3.png" alt="Apps settings with Advanced settings highlighted" />
+    </Frame>
+  </Step>
+
+  <Step title="Enable Developer mode">
+    Toggle **Developer mode** on. ChatGPT shows an **ELEVATED RISK** warning and notes that Memory will be disabled.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-4.png" alt="Developer mode toggle enabled with elevated risk warning" />
+    </Frame>
+
+    Read the warning before continuing. Leave **Enforce CSP in developer mode** off unless you specifically need it.
+  </Step>
+
+  <Step title="Open the Create app dialog">
+    Once developer mode is on, a **Create app** button appears at the top of the page. Click it.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-5.png" alt="Create app button visible after enabling developer mode" />
+    </Frame>
+  </Step>
+
+  <Step title="Fill in the Sectors app details">
+    In the New App dialog, set:
+
+    - **Name**: `Sectors`
+    - **Description**: optional — e.g. *Indonesia, Singapore, and Malaysia market data via the Sectors API*
+    - **MCP Server URL**: `https://sectors-mcp.supertype.ai/mcp`
+    - **Authentication**: `OAuth`
+
+    Then check **I understand and want to continue** to acknowledge the custom-MCP risk notice.
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-6.png" alt="New App dialog with Sectors name, MCP URL, and OAuth selected" />
+    </Frame>
+  </Step>
+
+  <Step title="(Optional) Review Advanced OAuth settings">
+    You can leave Advanced OAuth settings alone — the Sectors MCP server supports **Dynamic Client Registration**, so ChatGPT discovers the auth, token, registration, and resource URLs automatically.
+
+    If you do open the panel, you'll see DCR selected as the registration method:
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-7.png" alt="Advanced OAuth settings with Dynamic Client Registration selected" />
+    </Frame>
+
+    And the discovered endpoints filled in for you:
+
+    <Frame>
+      <img className="block" src="/images/sectors-mcp/gpt-8.png" alt="OAuth endpoints auto-discovered from the Sectors MCP server" />
+    </Frame>
+
+    No edits are needed. Click **Create**.
+  </Step>
+
+  <Step title="Authorize Sectors">
+    ChatGPT opens the Sectors authorization page. Sign in if needed, review the requested permission (**Read access to Sectors API**), and click **Allow Access**. Your existing subscription limits and credits apply to all requests made through the app.
+  </Step>
+</Steps>
+
+## Verify It Works
+
+Open a new chat and call the app explicitly so ChatGPT routes the request to it:
+
+> Using the Sectors app, give me an overview of Bank Central Asia (BBCA).
+
+ChatGPT will ask for permission to run the `fetch-company-report` tool, then return the company's sector, market cap, last close price, and index memberships. Try a few more prompts from the [usage examples](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#usage-examples) in the main guide to confirm other tools work.
+
+## Managing Access
+
+- **Disable the app** — In the Apps settings dialog, find **Sectors** under your apps list and toggle it off (or remove it entirely).
+- **Turn off developer mode** — Once you've added the apps you want, you can leave developer mode on, but disable it when you don't need custom MCP apps. Re-enabling later does not delete previously added apps.
+- **Revoke from Sectors** — You can revoke the OAuth grant from your Sectors dashboard. After revoking, ChatGPT tool calls will fail with a 401 until you reconnect.
+
+## Troubleshooting
+
+**I don't see a Create app button.**
+Developer mode isn't enabled, or your ChatGPT plan doesn't expose custom MCP apps. Recheck **Advanced settings → Developer mode**, then confirm your plan supports custom connectors against [OpenAI's docs](https://platform.openai.com/docs/guides/apps-sdk).
+
+**Dynamic Client Registration fails or endpoints don't auto-populate.**
+This usually means the request to the MCP server was blocked (corporate network, ad blocker) or the server was briefly unreachable. Close and reopen the Create app dialog, then try again. If it still fails, check [status.supertype.ai](https://status.supertype.ai) — or fall back to entering endpoints manually under Advanced OAuth settings.
+
+**Authorization succeeds but tool calls return `401 Unauthorized`.**
+The OAuth grant was likely revoked from your Sectors dashboard, or your Insider subscription has lapsed. Remove and re-add the Sectors app to trigger a fresh OAuth flow.
+
+**ChatGPT isn't calling the Sectors app even though it's enabled.**
+ChatGPT sometimes won't route to a custom app unless you mention it by name. Prefix prompts with *"Using the Sectors app, ..."* or *"With Sectors, ..."* until you confirm it's being picked up consistently.
+
+**Memory disappeared after enabling developer mode.**
+This is expected — ChatGPT disables Memory while developer mode is on. Turn developer mode off (your apps stay added) to restore Memory.
+
+## Next Steps
+
+- [Full tools reference and usage examples](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#tools-reference) — what each of the 40+ tools returns.
+- [Sectors Agent Skills](/recipes/sectors-for-ai-agents/01-agent-skills-guide) — alternative skill-based integration if you prefer not to use developer mode.


### PR DESCRIPTION
Add two new recipe pages covering the OAuth custom-connector setup for Claude (web + Desktop) and ChatGPT, both pointing at the /mcp endpoint. Strip the now-redundant Claude Desktop API-key config and Windows troubleshooting block from the original MCP guide and link out to the new Claude page instead. Register both pages in mint.json.