### PR TITLE
fix(seo): 308 redirect for /recipes and /recipes/generative-ai-python from Google Search Console issue (page with redirects)

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -57,13 +57,13 @@
       "name": "Recipes",
       "version": "v2",
       "icon": "lightbulb",
-      "url": "recipes"
+      "url": "/recipes/quick-start-in-python/00-your-first-request"
     },
     {
       "name": "Generative AI Series",
       "version": "v2",
       "icon": "microchip-ai",
-      "url": "recipes/generative-ai-python"
+      "url": "/recipes/generative-ai-python/01-background"
     },
     {
       "name": "Community",
@@ -489,6 +489,14 @@
     "linkedin": "https://www.linkedin.com/showcase/sectorsapp/"
   },
   "redirects": [
+    {
+      "source": "/recipes",
+      "destination": "/recipes/quick-start-in-python/00-your-first-request"
+    },
+    {
+      "source": "/recipes/generative-ai-python",
+      "destination": "/recipes/generative-ai-python/01-background"
+    },
     {
       "source": "/v1/sgx/companies/top",
       "destination": "/api-references/singapore/sgx-top-companies"


### PR DESCRIPTION
Resolves GSC 'Page with redirect' warning on /recipes and /recipes/.

- anchors: point Recipes + Generative AI Series to absolute child paths
- redirects: add 308 for /recipes and /recipes/generative-ai-python to their first child page, terminating the redirect chain on an indexable 200.