### PR TITLE
update: replace SSE transport with Streamable HTTP (/mcp) across agen…

### DIFF
--- a/recipes/sectors-for-ai-agents/00-sectors-mcp-guide.mdx
+++ b/recipes/sectors-for-ai-agents/00-sectors-mcp-guide.mdx
@@ -21,7 +21,7 @@ MCP uses a **client-server model** where the AI app (client) connects to an MCP 
 
 There are two transport types in MCP, which determine how the server connects and runs:
 - **stdio**: Local subprocess. This means that the MCP server runs on your local machine.
-- **SSE** (Server-Sent Events): Remote server over HTTP. This means that the MCP server runs remotely and is accessible over the internet.
+- **Streamable HTTP**: Remote server over HTTP. This means that the MCP server runs remotely and is accessible over the internet.
 
 ### What is Sectors MCP?
 The **Sectors MCP Server** is a cloud-hosted service built on MCP that gives your AI assistant access to **financial market data and analytics** through a standardized interface. Once connected, you can fetch a variety of market and company data, such as:
@@ -44,7 +44,7 @@ Before beginning, make sure you have:
    - [Claude Desktop](https://claude.ai/download)
    - [Cursor](https://cursor.com)
    - [VS Code](https://code.visualstudio.com) (with GitHub Copilot)
-   - [Windsurf](https://windsurf.com/), [JetBrains IDEs](https://www.jetbrains.com/), or any client that supports SSE transport
+   - [Windsurf](https://windsurf.com/), [JetBrains IDEs](https://www.jetbrains.com/), or any client that supports Streamable HTTP transport
 
 ## Quick Start Setup
 
@@ -56,8 +56,8 @@ Before beginning, make sure you have:
 Run the following command in your terminal:
 
 ```bash
-claude mcp add --transport sse sectors https://sectors-mcp.supertype.ai/sse \
-  --header "Authorization: Bearer YOUR_API_KEY_HERE"
+claude mcp add -t http sectors https://sectors-mcp.supertype.ai/mcp \
+  -H "Authorization: Bearer YOUR_API_KEY_HERE"
 ```
 
 Replace `YOUR_API_KEY_HERE` with your Sectors Financial API key. The server will be available in your next Claude Code session.
@@ -69,7 +69,7 @@ Open or create `~/.cursor/mcp.json` and add the following:
 {
   "mcpServers": {
     "sectors": {
-      "url": "https://sectors-mcp.supertype.ai/sse",
+      "url": "https://sectors-mcp.supertype.ai/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_KEY_HERE"
       }
@@ -87,8 +87,8 @@ Create a `.vscode/mcp.json` file in your workspace and add the following:
 {
   "servers": {
     "sectors": {
-      "type": "sse",
-      "url": "https://sectors-mcp.supertype.ai/sse",
+      "type": "http",
+      "url": "https://sectors-mcp.supertype.ai/mcp",
       "headers": {
         "Authorization": "Bearer ${input:sectors-api-key}"
       }
@@ -107,13 +107,13 @@ Create a `.vscode/mcp.json` file in your workspace and add the following:
 
 VS Code will securely prompt you for your Sectors Financial API key the first time the server starts. This config is workspace-scoped, so you'll need it in each project where you want Sectors data.
 
-### Generic SSE Client
-If you're using any other MCP-compatible client that supports SSE transport, connect with these settings:
+### Generic Streamable HTTP Client
+If you're using any other MCP-compatible client that supports Streamable HTTP transport, connect with these settings:
 
 | Setting | Value |
 |---|---|
-| Transport | `sse` |
-| URL | `https://sectors-mcp.supertype.ai/sse` |
+| Transport | `http` |
+| URL | `https://sectors-mcp.supertype.ai/mcp` |
 | Authorization header | `Bearer YOUR_API_KEY_HERE` |
 
 ## Usage Examples

--- a/recipes/sectors-for-ai-agents/02-sectors-in-claude.mdx
+++ b/recipes/sectors-for-ai-agents/02-sectors-in-claude.mdx
@@ -7,12 +7,12 @@ sidebarTitle: "3. Sectors in Claude"
 
 Sectors is available as a **custom connector** inside Claude — connect once with OAuth and Claude can pull live IDX, SGX, and KLSE data into any conversation. No API key to paste into a config file, no JSON to edit, and access is revocable from your Sectors dashboard at any time.
 
-This guide covers the OAuth flow on **claude.ai (web)** and the **Claude Desktop** app. If you're setting up Claude Code, Cursor, VS Code, or any other SSE-based client, see [Use Sectors MCP Server for Financial Analysis](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide).
+This guide covers the OAuth flow on **claude.ai (web)** and the **Claude Desktop** app. If you're setting up Claude Code, Cursor, VS Code, or any other Streamable HTTP client, see [Use Sectors MCP Server for Financial Analysis](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide).
 
 | Setup style | Best for | Auth | Endpoint |
 |---|---|---|---|
 | **OAuth custom connector** (this guide) | claude.ai, Claude Desktop | Browser sign-in | `https://sectors-mcp.supertype.ai/mcp` |
-| API key + SSE | Claude Code, Cursor, VS Code, JetBrains | `Bearer YOUR_API_KEY` header | `https://sectors-mcp.supertype.ai/sse` |
+| API key + Streamable HTTP | Claude Code, Cursor, VS Code, JetBrains | `Bearer YOUR_API_KEY` header | `https://sectors-mcp.supertype.ai/mcp` |
 
 ## Prerequisites
 
@@ -118,7 +118,7 @@ This usually means you're signed into the wrong Sectors account, or your session
 The OAuth grant may have been revoked from your Sectors dashboard, or your Insider subscription has lapsed. Reconnect the connector — Claude will redirect you to authorize again.
 
 **A tool returns an empty array.**
-Same causes as the SSE flow: wrong subsector slug, ticker not found, or a date range with no trading days. See the [data & coverage FAQ](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#data-coverage) in the main guide.
+Same causes as the API key flow: wrong subsector slug, ticker not found, or a date range with no trading days. See the [data & coverage FAQ](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide#data-coverage) in the main guide.
 
 ## Next Steps
 

--- a/recipes/sectors-for-ai-agents/03-sectors-in-chatgpt.mdx
+++ b/recipes/sectors-for-ai-agents/03-sectors-in-chatgpt.mdx
@@ -7,7 +7,7 @@ sidebarTitle: "4. Sectors in ChatGPT"
 
 Sectors can be connected to ChatGPT as a **custom MCP app**. Once added, ChatGPT can call any of the 40+ Sectors tools — company reports, top movers, quarterly financials, SGX coverage, and more — directly inside a chat. Authentication uses OAuth with Dynamic Client Registration, so there's no API key to copy and paste.
 
-This guide covers ChatGPT on the web. If you're using Claude or an SSE-based client, see:
+This guide covers ChatGPT on the web. If you're using Claude or a Streamable HTTP client, see:
 
 - [Connect Sectors to Claude with OAuth](/recipes/sectors-for-ai-agents/02-sectors-in-claude)
 - [Use Sectors MCP Server for Financial Analysis](/recipes/sectors-for-ai-agents/00-sectors-mcp-guide) (Claude Code, Cursor, VS Code, etc.)


### PR DESCRIPTION
Summary
-----------
PR to update all agent guides regarding the change on SSE transport (/sse) to Streamable HTTP (/mcp)

Changes
- Replaced all /sse endpoint URLs with /mcp
- Updated transport type from sse to http in Claude Code CLI, VS Code, and Cursor configs
- Renamed "Generic SSE Client" section to "Generic Streamable HTTP Client"
- Updated prose references from "SSE-based client" to "Streamable HTTP client"

Files changed
- recipes/sectors-for-ai-agents/00-sectors-mcp-guide.mdx
- recipes/sectors-for-ai-agents/02-sectors-in-claude.mdx
- recipes/sectors-for-ai-agents/03-sectors-in-chatgpt.mdx